### PR TITLE
Display all pulsar api versions as list

### DIFF
--- a/docs/api/pulsar.md
+++ b/docs/api/pulsar.md
@@ -2,7 +2,7 @@
 title: Pulsar API
 layout: doc.ejs
 includeTemplate:
-  - latest_pulsar_version
+  - pulsar_versions
 ---
 
 The Pulsar API is what makes Pulsar so incredibly customizable. All packages consume it, including the packages built into the editor.

--- a/helpers/index.js
+++ b/helpers/index.js
@@ -1,5 +1,7 @@
-
 // View helpers. Available in EJS templates via the `helpers` namespace.
+
+const fs = require("fs");
+const semver = require("semver");
 
 module.exports = {
   nextAndPreviousSidebarEntries(url, sidebar) {
@@ -12,5 +14,33 @@ module.exports = {
       if (index < lastIndex) next = sidebar[index + 1];
     }
     return [prev, next];
+  },
+
+  getAllPulsarVersions() {
+    // Returns an array of Pulsar semver versions, in order, and without 'latest'
+
+    let verArr = [];
+
+    const verDocs = fs.readdirSync("./pulsar-api/content");
+
+    for (const doc of verDocs) {
+      let clean = doc.replace(".json", "");
+
+      let name = clean;
+
+      if (!name.startsWith("v")) {
+        name = "v" + name;
+      }
+
+      verArr.push({
+        name: name,
+        link: clean
+      });
+    }
+
+    // Sort version array in order
+    verArr.sort((a, b) => { return semver.rcompare(a.name, b.name); });
+
+    return verArr;
   }
 };

--- a/layouts/latest_pulsar_version.ejs
+++ b/layouts/latest_pulsar_version.ejs
@@ -1,6 +1,0 @@
-
-<button class="button primary">
-  <a href="/api/pulsar/latest">
-    Latest API Documentation
-  </a>
-</button>

--- a/layouts/pulsar_versions.ejs
+++ b/layouts/pulsar_versions.ejs
@@ -8,25 +8,22 @@
   <li class="list-item">
     <div class="list-item__inner">
       <h3 class="list-item__name">
-        <button class="button primary">
-          <a href="/api/pulsar/latest">
-            Latest API Documentation
-          </a>
-        </button>
+        <a href="/api/pulsar/latest">
+          Latest API documentation
+        </a>
       </h3>
     </div>
   </li>
 
+  <h3>All versions</h3>
   <% for (const pulsarVersion of pulsarApiVersions) { %>
     <li class="list-item">
       <div class="list-item__inner">
-        <h3 class="list-item__name">
-          <button class="button secondary">
-            <a href="/api/pulsar/<%=pulsarVersion.link%>">
-              <%=pulsarVersion.name%>
-            </a>
-          </button>
-        </h3>
+        <h4 class="list-item__name">
+          <a href="/api/pulsar/<%=pulsarVersion.link%>">
+            <%=pulsarVersion.name%>
+          </a>
+        </h4>
       </div>
     </li>
   <% } %>

--- a/layouts/pulsar_versions.ejs
+++ b/layouts/pulsar_versions.ejs
@@ -1,0 +1,34 @@
+
+<%
+  const pulsarApiVersions = helpers.getAllPulsarVersions();
+-%>
+
+<ul class="list">
+
+  <li class="list-item">
+    <div class="list-item__inner">
+      <h3 class="list-item__name">
+        <button class="button primary">
+          <a href="/api/pulsar/latest">
+            Latest API Documentation
+          </a>
+        </button>
+      </h3>
+    </div>
+  </li>
+
+  <% for (const pulsarVersion of pulsarApiVersions) { %>
+    <li class="list-item">
+      <div class="list-item__inner">
+        <h3 class="list-item__name">
+          <button class="button secondary">
+            <a href="/api/pulsar/<%=pulsarVersion.link%>">
+              <%=pulsarVersion.name%>
+            </a>
+          </button>
+        </h3>
+      </div>
+    </li>
+  <% } %>
+
+</ul>


### PR DESCRIPTION
This PR adds a listing of all Pulsar API doc versions on the summary page, instead of just the latest.

It builds from the presence of `pulsar-api/content/*.json` files, just like the doc generator does.