### PR TITLE
Tweak prose in word count package tutorial

### DIFF
--- a/docs/developing-for-pulsar/package-word-count.md
+++ b/docs/developing-for-pulsar/package-word-count.md
@@ -19,6 +19,8 @@ Your new project will also automatically be opened for editing. The boilerplate 
 
 ![Wordcount Package is Alive Dialog](/img/atom/toggle.png)
 
+You can dismiss the dialog by executing the command again.
+
 ## Understanding the generated code
 
 Let's take a look at the code in our `lib` directory and see what is happening.

--- a/docs/developing-for-pulsar/package-word-count.md
+++ b/docs/developing-for-pulsar/package-word-count.md
@@ -7,7 +7,7 @@ Let's get started by writing a very simple package that will tell you how many w
 
 The simplest way to start a package is to use the built-in package generator that ships with Pulsar. As you might expect by now, this generator is itself a separate package implemented in {package-generator}.
 
-You can run the generator by invoking the command palette and searching for "Generate Package". A dialog will appear asking you to name your new project. Name it `your-name-word-count`. Atom will then create that directory and fill it out with a skeleton project and link it into your `~/.pulsar/packages` directory so it's loaded when you launch your editor next time.
+You can run the generator by invoking the command palette and searching for "Generate Package". A dialog will appear asking you to name your new project. Name it `your-name-word-count`. Pulsar will then create that directory and fill it out with a skeleton project and link it into your `~/.pulsar/packages` directory so it's loaded when you launch your editor next time.
 
 ::: tip
 
@@ -115,7 +115,7 @@ There is a bit more going on here. We’re defining four methods here, but the o
 
 The `deactivate` and `serialize` methods are expected by Pulsar but optional: if present, they’ll be called when the package is deactivated and when the window is closed, respectively.
 
-The `toggle` method isn’t a method that Pulsar itself knows or cares about; for it to be called, we’ll have to invoke it ourselves. We could hook it up to a menu option, or define a command that calls that method, or wire up an event handlers to call that method when some sort of editor event happens.
+The `toggle` method isn’t a method that Pulsar itself knows or cares about; for it to be called, we’ll have to invoke it ourselves. We could hook it up to a menu option, or define a command that calls that method, or wire up an event handler to call that method when some sort of editor event happens.
 
 ### The `activate` method
 


### PR DESCRIPTION
This PR contains a few minor suggestions for the ["Package: Word count" page](https://docs.pulsar-edit.dev/developing-for-pulsar/package-word-count/):

* Change one instance of "Atom" to "Pulsar"
* Spell out how a displayed dialog can be dismissed (early on)
* Change "handlers" to "handler"

Regarding the second change listed above, the background is...

While following the tutorial, when the command to toggle the dialog was described, I tried it out and got stuck for a bit.  My first few attempts to dismiss the dialog failed (e.g. pressing the `Esc` key, clicking in various spots of Pulsar, etc.).  After some head-scratching, it occurred to me to try the command again (^^;