### PR TITLE
Fix some links

### DIFF
--- a/docs/developing-for-pulsar/index.md
+++ b/docs/developing-for-pulsar/index.md
@@ -11,6 +11,6 @@ Most of the ways you can customize Pulsar can be bundled and distributed as a pa
 
 * add a new user interface to Pulsar
 * support another package by providing data to it (via a [service](/infrastructure/interacting-with-other-packages-via-services/))
-* add a [syntax theme](../developing-a-theme/)
-* add a [UI theme](../developing-a-theme/)
-* add one or more [language grammars](../creating-a-grammar/)
+* add a [syntax theme](developing-a-theme/)
+* add a [UI theme](developing-a-theme/)
+* add one or more [language grammars](creating-a-grammar/)


### PR DESCRIPTION
This PR contains a few suggested changes to links on the ["Developing for Pulsar" page](https://docs.pulsar-edit.dev/developing-for-pulsar/).

Clicking on the links for the following text yield 404s here:

* add a [syntax theme](https://docs.pulsar-edit.dev/developing-a-theme/)
* add a [UI theme](https://docs.pulsar-edit.dev/developing-a-theme/)
* add one or more [language grammars](https://docs.pulsar-edit.dev/creating-a-grammar/)

It looks like the intended pages exist and slight modifications seem to work:

* add a [syntax theme](https://docs.pulsar-edit.dev/developing-for-pulsar/developing-a-theme)
* add a [UI theme](https://docs.pulsar-edit.dev/developing-for-pulsar/developing-a-theme)
* add one or more [language grammars](https://docs.pulsar-edit.dev/developing-for-pulsar/creating-a-grammar)