### PR TITLE
Auto Update Docs

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -1,0 +1,56 @@
+name: Update Documentation
+
+on:
+  issues:
+    types: [ labeled ]
+
+jobs:
+  update_docs:
+    if: contains(github.event.issue.labels.*.name, 'update-docs')
+    runs-on: ubuntu
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+    - name: Checkout Latest Code
+      uses: actions/checkout@v3
+
+    - name: Install NodeJS
+      uses: actions/setup-node@v3
+      with:
+        node-version: 18
+
+    - name: Install Dependencies
+      run: npm install
+
+    - name: Setup Submodules
+      run: git submodule init
+
+    - name: Install Submodules
+      run: git submodule update
+
+    - name: Update Submodules
+      run: git submodule update --remote --merge
+
+    - name: Update Latest Pulsar Version
+      run: node ./pulsar-api/update-latest-script.js ${{ github.event.issue.title }}
+
+    - name: Update Documentation
+      run: npm run generate:docs
+
+    - name: Create Pull Request with Changes
+      uses: peter-evans/create-pull-request@v4
+      with:
+        # If we ever start running tests on PRs we will need to provide a custom
+        # PAT token here to ensure additional workflows are allowed to run.
+        # https://github.com/pulsar-edit/pulsar-chocolatey/blob/main/.github/workflows/draft_publish.yml
+        # token: ${{ secrets.<TOKEN_NAME_TO_ADD> }}
+        commit-message: Auto update source code documentation
+        branch: docs-update-${{ github.event.issue.title }}
+        delete-branch: true
+        title: '[${{ github.event.issue.title }}] Documentation Update'
+        body: |
+          Automated update of Source Code documentation.
+          Will close #${{ github.event.issue.number }}
+        draft: false

--- a/README.md
+++ b/README.md
@@ -84,3 +84,20 @@ But for all other links, please do follow this rule and do not use relative link
 Examples: When linking to `/example/sub/page` from `/example/sub/hello`
   - Do: `/example/sub/page`
   - Do **NOT**: `../page`
+
+## Update Source Code Documentation
+
+### Auto
+
+Create an issue against this repository, with the title formatted strictly as the new Pulsar version number.
+Such as `1.124.0`
+
+Then once the issue is created, afterwards add the label `update-docs`
+
+After a short time a PR will be created against the repository with the changes to go ahead and review.
+
+### Manual
+
+1) Update the JSON file `./pulsar-api/latest.json` with the newest Pulsar version.
+2) Update all submodules to their latest commit, such as `git submodule update --remote --merge`
+3) Run `npm run generate:docs` to trigger the documentation to be updated.

--- a/pulsar-api/update-latest-script.js
+++ b/pulsar-api/update-latest-script.js
@@ -1,0 +1,10 @@
+// Updates the version in `latest.json` to the one provided when running this file 
+const fs = require("fs");
+const path = require("path");
+
+const newVer = process.argv.slice(2)[0]; // take first argument
+const verFile = JSON.parse(fs.readFileSync(path.join(__dirname, "./latest.json"), { encoding: "utf8" }));
+
+verFile.latest = newVer;
+
+fs.writeFileSync(path.join(__dirname, "./latest.json"), JSON.stringify(verFile, null, 2), { encoding: "utf8" });


### PR DESCRIPTION
Relates to #13 

This PR brings in a GitHub Action to auto update the source code documentation in the same manner we update [`pulsar-edit/pulsar-chocolatey`](https://github.com/pulsar-edit/pulsar-chocolatey).

That is:
* Create an issue with the title just containing the new Pulsar version.
* Once posted add a special issue label, in this case `update-docs`
* Afterwards a PR will be generated containing the changes that can be reviewed.

This behavior will not occur automatically. But will enable us to start generating documentation easily for any newest version of Pulsar.
Ideally, the creation of the initial issue will be further handled by our new release automation.