### PR TITLE
Upgrade actions to latest version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,14 +38,11 @@ jobs:
     - name: Build Site
       run: npm run build
 
-    - name: Setup Pages
-      uses: actions/configure-pages@v3
-
     - name: Upload Artifact
-      uses: actions/upload-pages-artifact@v1
+      uses: actions/upload-pages-artifact@v3
       with:
         path: "./_dist"
 
     - name: Deploy to GitHub pages
       id: deployment
-      uses: actions/deploy-pages@v2
+      uses: actions/deploy-pages@v4


### PR DESCRIPTION
The most recent runs of our deploy workflow are failing with the following error:

```
Secret source: Actions
Prepare workflow directory
Prepare all required actions
Getting action download info
Download action repository 'actions/checkout@v3' (SHA:f43a0e5ff2bd294095638e[18](https://github.com/pulsar-edit/documentation/actions/runs/13935837386/job/39003412046#step:1:22)286ca9a3d1956744)
Download action repository 'actions/setup-node@v3' (SHA:1a4442cacd436585916779262731d5b162bc6ec7)
Download action repository 'actions/configure-pages@v3' (SHA:b8130d9ab958b325bbde9786d62f2c97a9885a0e)
Download action repository 'actions/upload-pages-artifact@v1' (SHA:84bb4cd4b733d5c3[20](https://github.com/pulsar-edit/documentation/actions/runs/13935837386/job/39003412046#step:1:24)c9c9cfbc354937524f4d64)
Download action repository 'actions/deploy-pages@v2' (SHA:de14547edc9944350dc0481aa5b7afb08e75f254)
Getting action download info
Error: Missing download info for actions/upload-artifact@v3
```

It [seems](https://github.com/orgs/community/discussions/152695) that this error is due to an older, no longer supported, version of `actions/upload-pages-artifact`. So I've gone ahead and in this PR bumped:

* `actions/upload-pages-artifact` 
* `actions/deploy-pages`

I also looked further into the `actions/configure-pages` step and found it to not actually be needed, so I removed it.

According to that action's [docs](https://github.com/actions/configure-pages) it's purpose is to `A GitHub Action to enable Pages, extract various metadata about a site, and configure some supported static site generators.`, which of course we already have Pages enabled now, and no longer need this step.