### PR TITLE
Bump versions of actions that depend on `upload-artifact`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,10 +42,10 @@ jobs:
       uses: actions/configure-pages@v3
 
     - name: Upload Artifact
-      uses: actions/upload-pages-artifact@v1
+      uses: actions/upload-pages-artifact@v3
       with:
         path: "./_dist"
 
     - name: Deploy to GitHub pages
       id: deployment
-      uses: actions/deploy-pages@v2
+      uses: actions/deploy-pages@v4


### PR DESCRIPTION
We [can't use `actions/upload-artifact@v3`](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/) anymore. That means we can't use `actions/upload-pages-artifact@v1` anymore, since it depends on `actions/upload-artifact@v3`. I also bumped `actions/deploy-pages` to `v4`, since that's the version that [the upload-pages-artifact’s README](https://github.com/actions/upload-pages-artifact) uses in its example code.

I haven't tested this at all, but the current auto-deploy CI job is failing on `main`, so I figure this is the quickest way to get it working again.