### PR TITLE
Fix `robots.txt` to allow Google indexing

### DIFF
--- a/docs/robots.njk
+++ b/docs/robots.njk
@@ -4,4 +4,9 @@ eleventyExcludeFromCollections: true
 ---
 Sitemap: {{ default.url }}/sitemap.xml
 User-agent: *
+User-agent: AdsBot-Google-Mobile
+User-agent: AdsBot-Google
+User-agent: Mediapartners-Google
+Allow: /
+User-agent: FriendlyCrawler
 Disallow: /


### PR DESCRIPTION
Seems we at some point disallowed all bots from scanning the docs site.
This PR fixes that while carving out exclusions to ensure google search can keep working.

I've copied the `robots.txt` we are currently using on `packages.pulsar-edit.dev`, to also include the blocking of a very unfriendly crawler there.