### PR TITLE
Add Search Capability

### DIFF
--- a/docs/search-preview.11ty.js
+++ b/docs/search-preview.11ty.js
@@ -1,0 +1,28 @@
+module.exports =
+class SearchPreview {
+  constructor() {}
+  data() {
+    // Export Front Matter
+    return {
+      permalink: "/search-preview.json",
+      eleventyExcludeFromCollections: true
+    };
+  }
+  render(data) {
+    let obj = { pages: {} };
+
+    for (const pageIdx in data.collections.all) {
+      const page = data.collections.all[pageIdx];
+      if (page.page.outputFileExtension === "html") {
+        // Only include HTML content into our search preview file, since
+        // that's what we include in our search index file
+        obj.pages[page.url] = {
+          title: page.data.title,
+          summary: "A quick summary of the content of this page."
+        };
+      }
+    }
+
+    return JSON.stringify(obj);
+  }
+}

--- a/docs/search.js
+++ b/docs/search.js
@@ -1,0 +1,111 @@
+class SearchUtility {
+  constructor() {
+    this.api = "https://search.pulsar-edit.dev/search/docs";
+    this.isSearchUrl = location.pathname.startsWith("/search");
+
+    this.searchTerm = "";
+    this.searchResults = [];
+    this.searchPreviews = {};
+  }
+
+  async setup() {
+    if (!this.isSearchUrl) { return; }
+    // Get our search term
+    const paramsString = window.location.search;
+    const searchParams = new URLSearchParams(paramsString);
+    this.searchTerm = searchParams.get("q");
+
+    // Get our search preview
+    try {
+      const response = await fetch("/search-preview.json");
+
+      if (!response.ok) {
+        console.error(response);
+        return;
+      }
+
+      const data = await response.json();
+      this.searchPreviews = data.pages;
+    } catch(err) {
+      console.error(err);
+    }
+  }
+
+  async search() {
+    if (!this.isSearchUrl || this.searchTerm?.length === 0 || typeof this.searchTerm !== "string") {
+      return;
+    }
+
+    try {
+      const response = await fetch(`${this.api}?q=${this.searchTerm}`);
+
+      if (!response.ok) {
+        console.error(response);
+        return;
+      }
+
+      const data = await response.json();
+      this.searchResults = data.results;
+
+    } catch(err) {
+      console.error(err);
+      return;
+    }
+  }
+
+  display() {
+    const resultsContainer = document.createElement("ul");
+    resultsContainer.classList.add("list");
+
+    for (const result of this.searchResults) {
+      const resultPreview = this.searchPreviews[result.ref];
+
+      const node = document.createElement("li");
+      node.classList.add("list-item");
+      node.innerHTML = `
+        <div class="list-item__inner">
+          <div class="list-item__icon"></div>
+          <h3 class="list-item__name">
+            <a href="${this.createSearchLink(result)}">${resultPreview.title}</a>
+          </h3>
+          <div class="list-item__summary">${resultPreview.summary}</div>
+        </div>
+      `;
+
+      resultsContainer.append(node);
+    }
+
+    document.querySelector("main").append(resultsContainer);
+  }
+
+  createSearchLink(searchResult) {
+    // Takes a search result item directly from the search API, and creates a link
+    // to the content indicated by the result. Will use Text Fragments if supported
+    // in the current browser.
+    let link = searchResult.ref; // Base link
+
+    if (document.fragmentDirective !== undefined) {
+      // This browser supports text fragments
+      let fragment = "#:~:";
+
+      for (let term in searchResult.matchData.metadata) {
+        if (fragment.includes("text=")) {
+          // If we are appending additional fragments to a directive, add `&`
+          fragment = `${fragment}&`;
+        }
+        fragment = `${fragment}text=${term}`;
+      }
+
+      link = `${link}${fragment}`;
+    }
+
+    return link;
+  }
+}
+
+(async () => {
+  const search = new SearchUtility();
+  search.setup();
+  await search.search();
+  search.display();
+})();

--- a/docs/search/index.md
+++ b/docs/search/index.md
@@ -1,0 +1,4 @@
+---
+title: Search
+layout: search.ejs
+---

--- a/layouts/page_header.ejs
+++ b/layouts/page_header.ejs
@@ -17,6 +17,13 @@
     </nav>
 
     <nav class="page-header__actions">
+      <div class="search-bar">
+        <search>
+          <form role="search" action="/search/" method="GET">
+            <input type="search" name="q" />
+          </form>
+        </search>
+      </div>
       <div class="theme-switcher-menu">
         <button type="button" id="theme-switcher">
           <svg xmlns="http://www.w3.org/2000/svg" class="icon auto-icon" viewBox="0 0 1024 1024" fill="currentColor" aria-label="auto icon">

--- a/layouts/search.ejs
+++ b/layouts/search.ejs
@@ -1,0 +1,16 @@
+<%-include("header")%>
+
+  <body>
+    <%-include("page_header", { platform_switcher: true }) %>
+    <div class="content">
+      <main class="container">
+        <section class="header">
+          <h1 class="title" id="title"<%= title %></h1>
+        </section>
+
+        <%- content %>
+      </main>
+    </div>
+  </body>
+<script src="/search.js"></script>
+<%-include("footer")%>

--- a/less/page-header.less
+++ b/less/page-header.less
@@ -98,6 +98,10 @@ html {
     width: 100%;
   }
 
+  .page-header__actions {
+    display: contents;
+  }
+
   .page-header__link {
     .border-hover-effect();
     flex-direction: row;
@@ -133,6 +137,18 @@ html {
       display: none;
       width: var(--theme-switcher-height);
       height: var(--theme-switcher-height);
+    }
+  }
+}
+
+.search-bar {
+  display: flex;
+
+  search {
+    margin: 0;
+
+    input {
+      height: 2rem;
     }
   }
 }


### PR DESCRIPTION
Still largely a WIP, but this PR adds the ability to search across the docs site.

The general workflow:
* During build time we generate `search-preview.json` in the root of the site. This contains a JSON document with a title and summary of each page. The title is easy, but the summary we either need to build from the content, or add it as a required field for each doc page we have.
1) The user searches in the search box in the top corner of the site
2) Hitting enter redirects to `/search?q=searchTerm` 
3) The query is taken by client JS that executes the search against `https://search.pulsar-edit.dev` (This site needs CORs updates to work in production)
4) The search is returned by the site, and we then collect the `search-preview.json` file client side
5) Display results from the preview according to our returned search on the page.

## Items to Complete:
- [ ] Add the docs site into CORs for the search microservice
- [ ] Display skeleton loading items for while the search is executed
- [ ] Display errors or empty results to the user within the page
- [ ] Fix CSS for the search box
- [ ] Generate or add summaries of all docs pages

## How to Test

Testing this locally really sucks because of CORs, where even once we allow CORs requests from `docs` to `search` it'll still be broken locally. So below I'll add to methods to test locally based on what you want:

### Static search results: Good for styling the page or generic functionality

On line 53 of `search.js` add an assignment of `this.searchResults` to a static array. Such as:

```js
this.searchResults = [{"ref":"/using-pulsar/packages/","score":3.02,"matchData":{"metadata":{"shellcheck":{"body":{"position":[[10626,10]]}}}}}];
```

### Dynamic search results

If you need to actually have dynamic search results, you'll need to spin up a local instance of the search microservice.

So get the search microservice, with the most recent [PR](https://github.com/pulsar-edit/package-frontend/pull/149) (which adds CORs), and change the domain it adds to just be `res.append("Access-Control-Allow-Origin", "*");` to let `localhost` work.

Then start it up, and trigger the index of search results with a `POST localhost:8080/reindex/docs` 

Then in this PR change `this.api = http://localhost:8080/search/docs` 

Now you can properly test, bit of a pain, but is how I was able to get it working for making this PR.