### PR TITLE
Experiment with `pagefind` for search

### DIFF
--- a/docs/main.less
+++ b/docs/main.less
@@ -16,5 +16,6 @@
 @import 'less/api.less';
 @import 'less/variables.less';
 @import 'less/todo.less';
+@import 'less/search.less';
 
 @import 'less/octicons/octicons.less';

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -46,13 +46,7 @@ module.exports = (eleventyConfig) => {
       //
       // (Pagefind uses Wax, a Rust glob library whose negation syntax is not
       // very robust.)
-      glob: "{*.html,[b-z]*/**/*.html}"
-    });
-
-    await index.addDirectory({
-      // Now we can add back the only directory underneath `api` that we care
-      // about.
-      path: path.join(dir.output, 'api', 'pulsar', 'latest')
+      glob: "{*.html,[b-z]*/**/*.html,api/pulsar/latest/**/*.html}"
     });
 
     await index.writeFiles({

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -1,12 +1,18 @@
+const path = require('path');
+
 const pulsarApi = require("./pulsar-api/src/index.js");
 const hovercardResolution = require("./hovercard_resolution/index.js");
 const syntaxHighlight = require("@11ty/eleventy-plugin-syntaxhighlight");
 const less = require("less");
 const _helpers = require('./helpers');
 const PRISM_LANGUAGE_SCM = require('./plugins/prism-language-scm');
-const { execSync } = require('child_process');
 
 module.exports = (eleventyConfig) => {
+
+  // `pagefind` is ESM, so has to be `import`ed rather than `require`d. Can't
+  // use `await` at the top level or in this function (not until we upgrade to
+  // 11ty v3) so we'll do it later.
+  const pagefindImport = import('pagefind');
 
   eleventyConfig.setServerOptions({
     // Prevent the server from trying to do a clever hot-reload when only
@@ -15,16 +21,43 @@ module.exports = (eleventyConfig) => {
     domDiff: false
   });
 
+  // Regenerate the search index after changes.
   eleventyConfig.on("eleventy.after", async ({ dir }) => {
-    // Regenerate the search index after changes.
-    //
-    // TODO: If we converted this file to use ESM, we could import the
-    // `pagefind` library directly and use its Node API.
-    try {
-      execSync(`npx pagefind --site ${dir.output}`, { stdio: 'inherit' });
-    } catch (err) {
-      console.error(`[pagefind] Index failed:`, err);
-    }
+    // Now we can `await` the import we couldn't above.
+    let pagefind = await pagefindImport;
+
+    const { index } = await pagefind.createIndex({
+      excludeSelectors: [
+        ".sidebar",
+        ".page_header",
+        ".page_footer",
+        ".adjacent",
+        ".platform-win",
+        ".platform-mac"
+      ],
+      verbose: process.env.DEBUG
+    });
+
+    await index.addDirectory({
+      path: dir.output,
+      // This dumb glob allows us to exclude all of `api` except for the one set
+      // of API docs we care about (the latest). This works fine as long as `api`
+      // is the only section that starts with A.
+      //
+      // (Pagefind uses Wax, a Rust glob library whose negation syntax is not
+      // very robust.)
+      glob: "{*.html,[b-z]*/**/*.html}"
+    });
+
+    await index.addDirectory({
+      // Now we can add back the only directory underneath `api` that we care
+      // about.
+      path: path.join(dir.output, 'api', 'pulsar', 'latest')
+    });
+
+    await index.writeFiles({
+      outputPath: path.join(dir.output, 'pagefind')
+    });
   });
 
   eleventyConfig.addPlugin(syntaxHighlight, {

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -4,6 +4,7 @@ const syntaxHighlight = require("@11ty/eleventy-plugin-syntaxhighlight");
 const less = require("less");
 const _helpers = require('./helpers');
 const PRISM_LANGUAGE_SCM = require('./plugins/prism-language-scm');
+const { execSync } = require('child_process');
 
 module.exports = (eleventyConfig) => {
 
@@ -12,6 +13,18 @@ module.exports = (eleventyConfig) => {
     // Markdown is changed. We have JavaScript code that needs to react to
     // changed content, so it’s better to reload the page instead.
     domDiff: false
+  });
+
+  eleventyConfig.on("eleventy.after", async ({ dir }) => {
+    // Regenerate the search index after changes.
+    //
+    // TODO: If we converted this file to use ESM, we could import the
+    // `pagefind` library directly and use its Node API.
+    try {
+      execSync(`npx pagefind --site ${dir.output}`, { stdio: 'inherit' });
+    } catch (err) {
+      console.error(`[pagefind] Index failed:`, err);
+    }
   });
 
   eleventyConfig.addPlugin(syntaxHighlight, {

--- a/layouts/api/page.ejs
+++ b/layouts/api/page.ejs
@@ -1,6 +1,10 @@
 <!-- Pulsar API Documentation Page -->
-<%- include("header", { title: content.customData?.name ?? title }) %>
-
+<%
+  let pageTitle = (content.customData?.name ?? title);
+  let fullPageTitle = `${pageTitle} — Pulsar API documentation v${locals.version}`;
+  let searchTitle = `${pageTitle} (API documentation)`;
+%>
+<%- include("header", { title: fullPageTitle, searchTitle }) %>
 <body>
   <%- include("page_header", { platform_switcher: false }) %>
   <div class="content">
@@ -18,7 +22,6 @@
     -%>
     <main class="container">
       <section class="header">
-        <% let pageTitle = (content.customData?.name ?? title) %>
         <h1 class="title" id="title"><%= pageTitle %></h1>
       </section>
 

--- a/layouts/api/summary.ejs
+++ b/layouts/api/summary.ejs
@@ -1,5 +1,5 @@
 <!-- Pulsar API Documentation Summary Page -->
-<%- include("header") %>
+<%- include("header", { title: `Pulsar documentation v${title}` }) %>
 
   <body>
     <%- include("page_header", { platform_switcher: false }) %>

--- a/layouts/header.ejs
+++ b/layouts/header.ejs
@@ -5,6 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="color-scheme" id="meta-scheme" content="">
     <meta property="og:title" content="<%= locals.title %>">
+    <% if (locals.searchTitle) { %>
+    <meta name="search-title" data-pagefind-meta="title[content]" content="<%= locals.searchTitle %>">
+    <% } %>
     <link rel="shortcut icon" type="image/svg+xml" href="/static/favicon.svg">
     <link rel="icon" type="image/svg+xml" href="/static/favicon.svg">
     <link rel="apple-touch-icon" type="image/svg+xml" href="/static/favicon.svg">

--- a/layouts/header.ejs
+++ b/layouts/header.ejs
@@ -30,6 +30,25 @@
         document.documentElement.dataset.theme = theme;
       }
     </script>
+    <link href="/pagefind/pagefind-component-ui.css" rel="stylesheet">
+    <script src="/pagefind/pagefind-component-ui.js" type="module"></script>
+
+    <script type="module">
+      await import('/pagefind/pagefind-highlight.js');
+      new PagefindHighlight({
+        markContext: "main",
+        highlightParam: "highlight",
+        addStyles: false
+      });
+
+      {
+        let match = document.querySelector('mark.pagefind-highlight');
+        if (match) {
+          match.scrollIntoView();
+          match.classList.add('pagefind-highlight-animate');
+        }
+      }
+    </script>
 
     <link rel="stylesheet" href="/main.css" />
 

--- a/layouts/page_header.ejs
+++ b/layouts/page_header.ejs
@@ -8,7 +8,7 @@
       <a class="page-header__link" href="/api/pulsar">
         <span>Pulsar API</span>
       </a>
-      <a class="page-header__link" href="https://api.pulsar-edit.dev/swagger-ui/">
+      <a class="page-header__link page-header__link--registry" href="https://api.pulsar-edit.dev/swagger-ui/">
         <span>Package Registry API</span>
       </a>
       <a class="page-header__link" href="https://pulsar-edit.dev">
@@ -34,7 +34,10 @@
         highlight-param="highlight"
         excerpt-length="60"
       ></pagefind-config>
-      <pagefind-modal-trigger></pagefind-modal-trigger>
+
+      <pagefind-modal-trigger class="page-header__search-trigger--full"></pagefind-modal-trigger>
+      <pagefind-modal-trigger class="page-header__search-trigger--compact" compact hide-shortcut></pagefind-modal-trigger>
+
       <pagefind-modal>
         <pagefind-modal-header>
           <pagefind-input></pagefind-input>

--- a/layouts/page_header.ejs
+++ b/layouts/page_header.ejs
@@ -16,6 +16,80 @@
       </a>
     </nav>
 
+    <style>
+      pagefind-modal-body:has(.pf-result) .pf-skeleton-text {
+        display: none !important;
+      }
+      p.pf-skeleton-text {
+        font-size: 25px !important;
+        text-align: center !important;
+        color: var(--pf-text-muted) !important;
+        font-family: var(--pf-font) !important;
+        font-weight: 600 !important;
+      }
+    </style>
+
+    <nav class="page-header__search">
+      <pagefind-config
+        highlight-param="highlight"
+        excerpt-length="60"
+      ></pagefind-config>
+      <pagefind-modal-trigger></pagefind-modal-trigger>
+      <pagefind-modal>
+        <pagefind-modal-header>
+          <pagefind-input></pagefind-input>
+        </pagefind-modal-header>
+        <pagefind-modal-body>
+          <pagefind-summary></pagefind-summary>
+          <pagefind-results hide-sub-results>
+            <script type="text/pagefind-template">
+              <li class="pf-result">
+                <div class="pf-result-card">
+                  {{#if and(options.show_images, meta.image)}}
+                  <img class="pf-result-image" src="{{ meta.image | resolveUrl(meta.url | default(url)) }}" alt="{{ meta.image_alt | default(meta.title) }}">
+                  {{/if}}
+                  <div class="pf-result-content">
+                    <p class="pf-result-title">
+                      <a class="pf-result-link" href="{{ meta.url | default(url) | safeUrl }}"{{#if options.link_target}} target="{{ options.link_target }}"{{/if}}{{#if eq(options.link_target, "_blank")}} rel="noopener"{{/if}}>{{ meta.title }}</a>
+                    </p>
+                    {{#if excerpt}}
+                    <p class="pf-result-excerpt">{{+ excerpt +}}</p>
+                    {{/if}}
+                  </div>
+                </div>
+                {{#if sub_results}}
+                <ul class="pf-heading-chips">
+                  {{#each sub_results as sub}}
+                  <li class="pf-heading-chip">
+                    <a class="pf-heading-link" href="{{ sub.url | safeUrl }}"{{#if options.link_target}} target="{{ options.link_target }}"{{/if}}{{#if eq(options.link_target, "_blank")}} rel="noopener"{{/if}}>{{ sub.title }}</a>
+                    <p class="pf-heading-excerpt">{{+ sub.excerpt +}}</p>
+                  </li>
+                  {{/each}}
+                </ul>
+                {{/if}}
+              </li>
+            </script>
+
+            <script type="text/pagefind-template" data-template="placeholder">
+              <li class="pf-result" aria-hidden="true">
+                <div class="pf-result-card">
+                  <div class="pf-skeleton pf-skeleton-image"></div>
+                  <div class="pf-result-content">
+                    <p class="pf-result-title pf-skeleton pf-skeleton-title">Type a search term</p>
+                    <p class="pf-result-excerpt pf-skeleton pf-skeleton-excerpt"></p>
+                  </div>
+                </div>
+              </li>
+            </script>
+
+          </pagefind-results>
+        </pagefind-modal-body>
+        <pagefind-modal-footer>
+          <pagefind-keyboard-hints></pagefind-keyboard-hints>
+        </pagefind-modal-footer>
+      </pagefind-modal>
+    </nav>
+
     <nav class="page-header__actions">
       <div class="theme-switcher-menu">
         <button type="button" id="theme-switcher">
@@ -30,8 +104,11 @@
           </svg>
         </button>
       </div>
+
     </nav>
   </div>
+
+
 </header>
 
 <% if (platform_switcher) { -%>

--- a/less/page-header.less
+++ b/less/page-header.less
@@ -98,6 +98,11 @@ html {
     width: 100%;
   }
 
+  .page-header__search {
+    position: relative;
+    top: 4px;
+  }
+
   .page-header__link {
     .border-hover-effect();
     flex-direction: row;

--- a/less/page-header.less
+++ b/less/page-header.less
@@ -161,3 +161,28 @@ html {
     }
   }
 }
+
+@media (max-width: (@bp-larger-than-phablet - 1px)) {
+  .page-header .page-header__link--registry {
+    display: none;
+  }
+}
+
+// Show the compact search widget…
+.page-header__search-trigger--full {
+  display: none;
+}
+.page-header__search-trigger--compact {
+  display: inline-block;
+}
+
+
+// …but swap in the bigger one when we have the room.
+@media(min-width: @bp-larger-than-tablet) {
+  .page-header__search-trigger--full {
+    display: inline-block;
+  }
+  .page-header__search-trigger--compact {
+    display: none;
+  }
+}

--- a/less/search.less
+++ b/less/search.less
@@ -1,0 +1,102 @@
+:root {
+  /* Colors */
+  --pf-text: var(--font-color);
+  --pf-text-secondary: var(--font-color-subtle);
+  --pf-text-muted: var(--link-color-subtle);
+  --pf-background: var(--body-color);
+  --pf-border: var(--btn-border);
+  --pf-border-focus: var(--kbd-border);
+  --pf-skeleton: var(--body-color);
+  --pf-skeleton-shine: var(--table-border);
+  --pf-hover: var(--btn-bg-hover);
+  --pf-mark: var(--btn-color-focus);
+  --pf-scroll-shadow: rgba(0, 0, 0, 0.08);
+
+  /* Shadows */
+  --pf-shadow-sm: 0 2px 8px var(--_pf-shadow-color-sm);
+  --pf-shadow-md: 0 4px 12px var(--_pf-shadow-color-med);
+  --pf-shadow-lg: 0 16px 48px var(--_pf-shadow-color-lg);
+
+  /* Error states */
+  --pf-error-bg: var(--alert-bg-danger);
+  --pf-error-border: var(--alert-border-danger);
+  --pf-error-text: var(--alert-color-title-danger);
+  --pf-error-text-secondary: var(--alert-color-danger);
+
+  /* Focus ring */
+  --pf-outline-focus: var(--input-field-border-focus);
+  --pf-outline-width: 2px;
+  --pf-outline-offset: 2px;
+
+  /* Typography */
+  --pf-font: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+
+  /* Sizing */
+  --pf-input-height: 36px;
+  --pf-input-font-size: 16px; /* Keep at 16px+ to prevent iOS auto-zoom on focus */
+  --pf-summary-font-size: 12px;
+  --pf-result-title-font-size: 14px;
+  --pf-result-excerpt-font-size: 13px;
+
+  /* Results layout */
+  --pf-results-display: flex;
+  --pf-results-flex-direction: column;
+  --pf-results-flex-wrap: nowrap;
+  --pf-results-columns: none; /* grid-template-columns value, used when display is grid */
+  --pf-results-gap: 8px;
+
+  --pf-border-radius: 6px;
+  --pf-image-width: 64px;
+  --pf-image-height: 48px;
+
+  /* Icons (SVG data URIs) */
+  // --pf-icon-search: url("data:image/svg+xml,...");
+  // --pf-icon-arrow: url("data:image/svg+xml,...");
+
+  /* Modal */
+  --pf-modal-backdrop: rgba(0, 0, 0, 0.5);
+  --pf-modal-max-width: 720px;
+  --pf-modal-max-height: min(80dvh, 800px);
+  --pf-modal-top: 10dvh;
+
+  /* Searchbox dimensions */
+  --pf-searchbox-max-width: 480px;
+  --pf-searchbox-dropdown-max-height: 320px;
+
+  /* Dropdown settings */
+  --pf-dropdown-max-height: 280px;
+  --pf-dropdown-z-index: 9999;
+}
+
+mark.pagefind-highlight {
+  display: inline-block;
+  background-color: var(--alert-bg-warning);
+  color: var(--alert-color-warning);
+  outline: 1px solid color-mix(in srgb, var(--alert-border-warning) 50%, transparent);
+  border-radius: 2px;
+}
+
+.pf-result-link {
+  color: var(--link-color) !important;
+}
+
+.pagefind-highlight-animate {
+  animation: pagefind-highlight-animation;
+  animation-iteration-count: 1;
+  animation-duration: 0.6s;
+  animation-timing-function: ease-in-out;
+}
+
+@keyframes pagefind-highlight-animation {
+  0% {
+    transform: scale(1);
+  }
+
+  50% {
+    transform: scale(1.2);
+  }
+
+  100% {
+    transform: scale(1);
+  }
+}

--- a/less/search.less
+++ b/less/search.less
@@ -80,6 +80,15 @@ mark.pagefind-highlight {
   color: var(--link-color) !important;
 }
 
+// Style the trigger keys (which should be `kbd` elements!) like our `kbd`
+// elements.
+.pf-trigger-key {
+  padding: 0.125rem 0.5rem;
+  border: 1.5px solid var(--kbd-border, var(--btn-border)) !important;
+  border-radius: 3px !important;
+  box-shadow: 0px 1.5px 0px var(--kbd-border, var(--btn-border)) !important;
+}
+
 .pagefind-highlight-animate {
   animation: pagefind-highlight-animation;
   animation-iteration-count: 1;

--- a/less/themes.less
+++ b/less/themes.less
@@ -46,7 +46,7 @@
   --btn-bg: hsl(0, 0%, 100%);
 
   --btn-color-hover: hsl(230, 1%, 14%);
-  --btn-border-hover: hsl(230, 1%, 866%);
+  --btn-border-hover: hsl(230, 1%, 86%);
   --btn-bg-hover: hsl(0, 0%, 96%);
 
   --btn-color-focus: hsl(230, 1%, 26%);
@@ -196,6 +196,10 @@
   // Code Documentation
   --api-entry-name-color: var(--link-color);
   --api-argument-color: var(--font-color-subtle);
+
+  --_pf-shadow-color-sm: hsla(230, 1%, 86%, 0.06);
+  --_pf-shadow-color-md: hsla(230, 1%, 86%, 0.1);
+  --_pf-shadow-color-lg: hsla(230, 1%, 86%, 0.2);
 }
 
 .dark-mode() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "markdown-it-container": "^4.0.0",
         "markdown-it-include": "^2.0.0",
         "markdown-it-kbd": "^2.2.2",
+        "pagefind": "^1.5.2",
         "pulsardoc": "github:confused-Techie/pulsardoc",
         "semver": "^7.6.0",
         "terser": "^5.28.1"
@@ -367,6 +368,104 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@pagefind/darwin-arm64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-arm64/-/darwin-arm64-1.5.2.tgz",
+      "integrity": "sha512-MXpI+7HsAdPkvJ0gk9xj9g541BCqBZOBbdwj9g6lB5LCj6kSV6nqDSjzcAJwvOsfu0fjwvC8hQU+ecfhp+MpiQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@pagefind/darwin-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-x64/-/darwin-x64-1.5.2.tgz",
+      "integrity": "sha512-IojxFWMEJe0RQ7PQ3KXQsPIImNsbpPYpoZ+QUDrL8fAl/O27IX+LVLs74/UzEZy5uA2LD8Nz1AiwKr72vrkZQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@pagefind/freebsd-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/freebsd-x64/-/freebsd-x64-1.5.2.tgz",
+      "integrity": "sha512-7EVzo9+0w+2cbe671BtMj10UlNo83I+HrLVLfRxO731svHRJKUfJ/mo05gU14pe9PCfpKNQT8FS3Xc/oDN6pOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@pagefind/linux-arm64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-arm64/-/linux-arm64-1.5.2.tgz",
+      "integrity": "sha512-Ovt9+K35sqzn8H3ZMXGwls4TD/wMJuvRtShHIsmUQREmaxjrDEX7gHckRCrwYJ4XE1H1p6HkLz3wukrAnsfXQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@pagefind/linux-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-x64/-/linux-x64-1.5.2.tgz",
+      "integrity": "sha512-V+tFqHKXhQKq/WqPBD67AFy7scn1/aZID00ws4fSDd+1daSi5UHR9VVlRrOUYKxn3VuFQYRD7lYXdZK1WED1YA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@pagefind/windows-arm64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/windows-arm64/-/windows-arm64-1.5.2.tgz",
+      "integrity": "sha512-hN9Nh90fNW61nNRCW9ZyQrAj/mD0eRvmJ8NlTUzkbuW8kIzGJUi3cxjFkEcMZ5h/8FsKWD/VcouZl4yo1F7B6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@pagefind/windows-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/windows-x64/-/windows-x64-1.5.2.tgz",
+      "integrity": "sha512-Fa2Iyw7kaDRzGMfNYNUXNW2zbL5FQVDgSOcbDHdzBrDEdpqOqg8TcZ68F22ol6NJ9IGzvUdmeyZypLW5dyhqsg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@sindresorhus/slugify": {
       "version": "1.1.2",
@@ -2413,6 +2512,25 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/pagefind": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/pagefind/-/pagefind-1.5.2.tgz",
+      "integrity": "sha512-XTUaK0hXMCu2jszWE584JGQT7y284TmMV9l/HX3rnG5uo3rHI/uHU56XTyyyPFjeWEBxECbAi0CaFDJOONtG0Q==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "pagefind": "lib/runner/bin.cjs"
+      },
+      "optionalDependencies": {
+        "@pagefind/darwin-arm64": "1.5.2",
+        "@pagefind/darwin-x64": "1.5.2",
+        "@pagefind/freebsd-x64": "1.5.2",
+        "@pagefind/linux-arm64": "1.5.2",
+        "@pagefind/linux-x64": "1.5.2",
+        "@pagefind/windows-arm64": "1.5.2",
+        "@pagefind/windows-x64": "1.5.2"
+      }
+    },
     "node_modules/parse-node-version": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parse-node-version/-/parse-node-version-1.0.1.tgz",
@@ -3731,6 +3849,55 @@
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
       }
+    },
+    "@pagefind/darwin-arm64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-arm64/-/darwin-arm64-1.5.2.tgz",
+      "integrity": "sha512-MXpI+7HsAdPkvJ0gk9xj9g541BCqBZOBbdwj9g6lB5LCj6kSV6nqDSjzcAJwvOsfu0fjwvC8hQU+ecfhp+MpiQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@pagefind/darwin-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-x64/-/darwin-x64-1.5.2.tgz",
+      "integrity": "sha512-IojxFWMEJe0RQ7PQ3KXQsPIImNsbpPYpoZ+QUDrL8fAl/O27IX+LVLs74/UzEZy5uA2LD8Nz1AiwKr72vrkZQw==",
+      "dev": true,
+      "optional": true
+    },
+    "@pagefind/freebsd-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/freebsd-x64/-/freebsd-x64-1.5.2.tgz",
+      "integrity": "sha512-7EVzo9+0w+2cbe671BtMj10UlNo83I+HrLVLfRxO731svHRJKUfJ/mo05gU14pe9PCfpKNQT8FS3Xc/oDN6pOA==",
+      "dev": true,
+      "optional": true
+    },
+    "@pagefind/linux-arm64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-arm64/-/linux-arm64-1.5.2.tgz",
+      "integrity": "sha512-Ovt9+K35sqzn8H3ZMXGwls4TD/wMJuvRtShHIsmUQREmaxjrDEX7gHckRCrwYJ4XE1H1p6HkLz3wukrAnsfXQw==",
+      "dev": true,
+      "optional": true
+    },
+    "@pagefind/linux-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-x64/-/linux-x64-1.5.2.tgz",
+      "integrity": "sha512-V+tFqHKXhQKq/WqPBD67AFy7scn1/aZID00ws4fSDd+1daSi5UHR9VVlRrOUYKxn3VuFQYRD7lYXdZK1WED1YA==",
+      "dev": true,
+      "optional": true
+    },
+    "@pagefind/windows-arm64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/windows-arm64/-/windows-arm64-1.5.2.tgz",
+      "integrity": "sha512-hN9Nh90fNW61nNRCW9ZyQrAj/mD0eRvmJ8NlTUzkbuW8kIzGJUi3cxjFkEcMZ5h/8FsKWD/VcouZl4yo1F7B6g==",
+      "dev": true,
+      "optional": true
+    },
+    "@pagefind/windows-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/windows-x64/-/windows-x64-1.5.2.tgz",
+      "integrity": "sha512-Fa2Iyw7kaDRzGMfNYNUXNW2zbL5FQVDgSOcbDHdzBrDEdpqOqg8TcZ68F22ol6NJ9IGzvUdmeyZypLW5dyhqsg==",
+      "dev": true,
+      "optional": true
     },
     "@sindresorhus/slugify": {
       "version": "1.1.2",
@@ -5219,6 +5386,21 @@
           "integrity": "sha512-1tMA907+V4QmxV7dbRvb4/8MaRALK6q9Abid3ndMYnbyo8piisCmeONVqVSXqQA3KaP4SLt5b7ud6E2sqP8TFw==",
           "dev": true
         }
+      }
+    },
+    "pagefind": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/pagefind/-/pagefind-1.5.2.tgz",
+      "integrity": "sha512-XTUaK0hXMCu2jszWE584JGQT7y284TmMV9l/HX3rnG5uo3rHI/uHU56XTyyyPFjeWEBxECbAi0CaFDJOONtG0Q==",
+      "dev": true,
+      "requires": {
+        "@pagefind/darwin-arm64": "1.5.2",
+        "@pagefind/darwin-x64": "1.5.2",
+        "@pagefind/freebsd-x64": "1.5.2",
+        "@pagefind/linux-arm64": "1.5.2",
+        "@pagefind/linux-x64": "1.5.2",
+        "@pagefind/windows-arm64": "1.5.2",
+        "@pagefind/windows-x64": "1.5.2"
       }
     },
     "parse-node-version": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "markdown-it-container": "^4.0.0",
     "markdown-it-include": "^2.0.0",
     "markdown-it-kbd": "^2.2.2",
+    "pagefind": "^1.5.2",
     "pulsardoc": "github:confused-Techie/pulsardoc",
     "semver": "^7.6.0",
     "terser": "^5.28.1"

--- a/pagefind.yaml
+++ b/pagefind.yaml
@@ -1,0 +1,15 @@
+
+site: "_dist"
+# This dumb glob allows us to exclude all of `api` except for the one set of
+# API docs we care about (the latest). This works fine as long as `api` is the
+# only section that starts with A.
+#
+# (Pagefind uses Wax, a Rust glob library whose negation syntax is not very
+# robust.)
+glob: "{*.html,[b-z]*/**/*.html,api/pulsar/latest/**/*.html}"
+
+exclude_selectors:
+  - ".sidebar"
+  - ".page_header"
+  - ".page_footer"
+  - ".adjacent"

--- a/pagefind.yaml
+++ b/pagefind.yaml
@@ -13,3 +13,5 @@ exclude_selectors:
   - ".page_header"
   - ".page_footer"
   - ".adjacent"
+  - ".platform-win"
+  - ".platform-mac"


### PR DESCRIPTION
It might seem like this PR’s existence implies that I think #43 is lacking in some way. Not at all; I was just compelled to try out [Pagefind](https://pagefind.app/) and was pleasantly surprised at how well it solved this problem.

Here's what this PR does:

* Makes it so that every page build (via `npm run build` or `npm run serve`) also regenerates the search index (which is incredibly fast)
* Adds a search field to the page header
* Integrates Pagefind's UI into our existing theme (assigning its CSS variables to analogous variables in our CSS theme, whether we're in light mode or dark mode)
* Ensures only the main content of pages (rather than sidebars, page headers, or page footers) gets indexed
* Sets up Pagefind’s plugin for highlighting search terms after you click on results
* Allows it to crawl the latest version of the API docs… but not _every_ version of the API docs, lest you get 17 near-identical results

I was also gratified that I managed to get this done without sprinkling _any_ of Pagefind’s [custom data attributes](https://pagefind.app/docs/indexing/) throughout the HTML. They say this is the “preferred” way of opting into indexing of certain pages and opting out of indexing others, but I was determined to avoid it if it could be helped. (Instead, I use CSS selectors to exclude certain portions of each page from being indexed, and use a silly glob to ensure only the latest API docs are indexed).

I owe a review of #43, so I'll get to that soon. But if we run into any snags with the search service, we might want to deploy this version as a stopgap, since it's better than having no search capability whatsoever!
